### PR TITLE
Spatial Additions to H2

### DIFF
--- a/h2/src/main/org/h2/Driver.java
+++ b/h2/src/main/org/h2/Driver.java
@@ -15,7 +15,7 @@ import org.h2.jdbc.JdbcConnection;
 import org.h2.message.DbException;
 import org.h2.upgrade.DbUpgrade;
 
-/*## Java 1.7 ##
+//## Java 1.7 ##
 import java.util.logging.Logger;
 //*/
 
@@ -143,8 +143,8 @@ public class Driver implements java.sql.Driver {
     /**
      * [Not supported]
      */
-/*## Java 1.7 ##
-    @Override
+//## Java 1.7 ##
+    //@Override
     public Logger getParentLogger() {
         return null;
     }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2118,7 +2118,7 @@ public class Parser {
             read(")");
             return new ConditionExists(query);
         }
-        if (readIf("INTERSECTS")) {
+        if (readIf("INTERSECT")) {
             read("(");
             Expression r1 = readConcat();
             read(",");

--- a/h2/src/main/org/h2/expression/Comparison.java
+++ b/h2/src/main/org/h2/expression/Comparison.java
@@ -16,6 +16,7 @@ import org.h2.table.TableFilter;
 import org.h2.util.New;
 import org.h2.value.Value;
 import org.h2.value.ValueBoolean;
+import org.h2.value.ValueDouble;
 import org.h2.value.ValueGeometry;
 import org.h2.value.ValueNull;
 
@@ -111,9 +112,21 @@ public class Comparison extends Condition {
 
     /**
      * This is another comparison type that is only used for spatial index
-     * conditions (operator "&&&").
+     * conditions (operator "&=").
      */
     public static final int SPATIAL_COVERS = 12;
+
+    /**
+     * This is special operator only used for spatial index
+     * conditions (operator "&<"). Used to expand geometries to find points "near" a geometry
+     */
+    public static final int SPATIAL_WITHIN_RADIUS = 13;
+
+    /**
+     * This is another comparison type that is only used for spatial index
+     * conditions (operator "&=").
+     */
+    //public static final int SPATIAL_NEAR = 13;
 
     private final Database database;
     private int compareType;
@@ -142,9 +155,12 @@ public class Comparison extends Condition {
             sql = "INTERSECTS(" + left.getSQL() + ", " + right.getSQL() + ")";
             break;
         case SPATIAL_COVERS:
-            // TODO: Need to support COVERS somewhere
+            // TODONE: Need to support COVERS somewhere
             sql = "COVERS(" + left.getSQL() + ", " + right.getSQL() + ")";
             break;
+        /*case SPATIAL_NEAR:
+            sql = "NEAR(" + left.getSQL() + ", " + right.getSQL() +  ", " + radius.getSQL() + ")";
+            break;*/
         default:
             sql = left.getSQL() + " " + getCompareOperator(compareType) +
                     " " + right.getSQL();
@@ -179,8 +195,10 @@ public class Comparison extends Condition {
         case SPATIAL_INTERSECTS:
             return "&&";
         case SPATIAL_COVERS:
-            //return "&&&";
             return "&=";
+        /*case SPATIAL_WITHIN_RADIUS:
+            // This isn't actually going to be a comparison operator because it produces a ValueGeometry, not a bool
+            return "&<";*/
         default:
             throw DbException.throwInternalError("compareType=" + compareType);
         }
@@ -318,6 +336,13 @@ public class Comparison extends Condition {
             result = lg.coversBoundingBox(rg);
             break;
         }
+        /*case SPATIAL_NEAR: {
+            ValueGeometry lg = (ValueGeometry) l.convertTo(Value.GEOMETRY);
+            ValueDouble rg = (ValueDouble) r.convertTo(Value.DOUBLE);
+            //result = lg.intersectsBoundingBox(rg);
+            result = lg.getBoundingRegion(rg.getDouble());
+            break;
+        }*/
         default:
             throw DbException.throwInternalError("type=" + compareType);
         }

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -61,6 +61,7 @@ import org.h2.value.ValueBoolean;
 import org.h2.value.ValueBytes;
 import org.h2.value.ValueDate;
 import org.h2.value.ValueDouble;
+import org.h2.value.ValueGeometry;
 import org.h2.value.ValueInt;
 import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
@@ -132,6 +133,8 @@ public class Function extends Expression implements FunctionCall {
     public static final int H2VERSION = 231;
 
     public static final int ROW_NUMBER = 300;
+
+    public static final int EXPAND_GEOMETRY = 256;
 
     private static final int VAR_ARGS = -1;
     private static final long PRECISION_UNKNOWN = -1;
@@ -479,6 +482,9 @@ public class Function extends Expression implements FunctionCall {
 
         // ON DUPLICATE KEY VALUES function
         addFunction("VALUES", VALUES, 1, Value.NULL, false, true, false);
+
+        // Function for expanding/ buffering a geometry
+        addFunction("EXPAND", EXPAND_GEOMETRY, 2, Value.GEOMETRY);
     }
 
     protected Function(Database database, FunctionInfo info) {
@@ -1657,6 +1663,12 @@ public class Function extends Expression implements FunctionCall {
         case VALUES:
             result = session.getVariable(args[0].getSchemaName() + "." +
                     args[0].getTableName() + "." + args[0].getColumnName());
+            break;
+        case EXPAND_GEOMETRY:
+            ValueGeometry g = ValueGeometry.get(StringUtils.xmlText(
+                    v0.getString()));
+            result =  g.expandGeometry(v1.getDouble());
+            System.out.println("RESULT OF GEOEXPAND: " + result.getSQL());
             break;
         default:
             throw DbException.throwInternalError("type=" + info.type);

--- a/h2/src/main/org/h2/index/IndexCondition.java
+++ b/h2/src/main/org/h2/index/IndexCondition.java
@@ -65,6 +65,12 @@ public class IndexCondition {
      */
     public static final int SPATIAL_INTERSECTS = 16;
 
+    /**
+     * A bit of a search mask meaning 'spatial covers'.
+     * TODO: Figure out the correct mask here, maybe not 16
+     */
+    public static final int SPATIAL_COVERS = 16;
+
     private final Column column;
     /**
      * see constants in {@link Comparison}
@@ -223,6 +229,9 @@ public class IndexCondition {
         case Comparison.SPATIAL_INTERSECTS:
             buff.append(" && ");
             break;
+        case Comparison.SPATIAL_COVERS:
+            buff.append(" &= ");
+            break;
         default:
             DbException.throwInternalError("type=" + compareType);
         }
@@ -269,6 +278,8 @@ public class IndexCondition {
             return END;
         case Comparison.SPATIAL_INTERSECTS:
             return SPATIAL_INTERSECTS;
+        case Comparison.SPATIAL_COVERS:
+            return SPATIAL_COVERS;
         default:
             throw DbException.throwInternalError("type=" + compareType);
         }
@@ -328,6 +339,8 @@ public class IndexCondition {
     public boolean isSpatialIntersects() {
         switch (compareType) {
         case Comparison.SPATIAL_INTERSECTS:
+            return true;
+        case Comparison.SPATIAL_COVERS:
             return true;
         default:
             return false;
@@ -426,6 +439,10 @@ public class IndexCondition {
         if ((i & SPATIAL_INTERSECTS) == SPATIAL_INTERSECTS) {
             s.appendExceptFirst("&");
             s.append("SPATIAL_INTERSECTS");
+        }
+        if ((i & SPATIAL_COVERS) == SPATIAL_COVERS) {
+            s.appendExceptFirst("&");
+            s.append("SPATIAL_COVERS");
         }
         return s.toString();
     }

--- a/h2/src/main/org/h2/index/SpatialTreeIndex.java
+++ b/h2/src/main/org/h2/index/SpatialTreeIndex.java
@@ -194,7 +194,8 @@ public class SpatialTreeIndex extends BaseIndex implements SpatialIndex {
         for (Column column : columns) {
             int index = column.getColumnId();
             int mask = masks[index];
-            if ((mask & IndexCondition.SPATIAL_INTERSECTS) != 0) {
+            // Might want to apply different cost function for covers than intersects, but unsure of what that would be
+            if (((mask & IndexCondition.SPATIAL_INTERSECTS) != 0) || ((mask & IndexCondition.SPATIAL_COVERS) != 0)) {
                 cost = 3 + rowCount / 4;
             }
         }

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -276,6 +276,10 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             if ((mask & IndexCondition.SPATIAL_INTERSECTS) != 0) {
                 setParameter(paramList, idx++, intersection.getValue(i));
             }
+            if ((mask & IndexCondition.SPATIAL_COVERS) != 0) {
+                // TODO: Set parameters to use spatial index for covers condition
+                setParameter(paramList, idx++, intersection.getValue(i));
+            }
         }
     }
 
@@ -352,6 +356,11 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             if ((mask & IndexCondition.SPATIAL_INTERSECTS) != 0) {
                 Parameter param = new Parameter(firstIndexParam + i);
                 q.addGlobalCondition(param, idx, Comparison.SPATIAL_INTERSECTS);
+                i++;
+            }
+            if ((mask & IndexCondition.SPATIAL_COVERS) != 0) {
+                Parameter param = new Parameter(firstIndexParam + i);
+                q.addGlobalCondition(param, idx, Comparison.SPATIAL_COVERS);
                 i++;
             }
         }

--- a/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
@@ -1569,7 +1569,7 @@ public class JdbcCallableStatement extends JdbcPreparedStatement implements
      * @param parameterIndex the parameter index (1, 2, ...)
      * @param type the class of the returned value
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public <T> T getObject(int parameterIndex, Class<T> type) {
         return null;
@@ -1582,7 +1582,7 @@ public class JdbcCallableStatement extends JdbcPreparedStatement implements
      * @param parameterName the parameter name
      * @param type the class of the returned value
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public <T> T getObject(String parameterName, Class<T> type) {
         return null;

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -27,7 +27,7 @@ import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
 
-/*## Java 1.7 ##
+//## Java 1.7 ##
 import java.util.concurrent.Executor;
 //*/
 
@@ -1896,7 +1896,7 @@ public class JdbcConnection extends TraceObject implements Connection {
      *
      * @param schema the schema
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public void setSchema(String schema) {
         // not supported
@@ -1906,7 +1906,7 @@ public class JdbcConnection extends TraceObject implements Connection {
     /**
      * [Not supported]
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public String getSchema() {
         return null;
@@ -1918,7 +1918,7 @@ public class JdbcConnection extends TraceObject implements Connection {
      *
      * @param executor the executor used by this method
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public void abort(Executor executor) {
         // not supported
@@ -1931,7 +1931,7 @@ public class JdbcConnection extends TraceObject implements Connection {
      * @param executor the executor used by this method
      * @param milliseconds the TCP connection timeout
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public void setNetworkTimeout(Executor executor, int milliseconds) {
         // not supported
@@ -1941,7 +1941,7 @@ public class JdbcConnection extends TraceObject implements Connection {
     /**
      * [Not supported]
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public int getNetworkTimeout() {
         return 0;

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -3133,7 +3133,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     /**
      * [Not supported]
      */
-    /*## Java 1.7 ##
+    //## Java 1.7 ##
     @Override
     public boolean generatedKeyAlwaysReturned() {
         return true;
@@ -3151,7 +3151,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @param columnNamePattern null (to get all objects) or a column name
      *            (uppercase for unquoted names)
      */
-    /*## Java 1.7 ##
+    //## Java 1.7 ##
     @Override
     public ResultSet getPseudoColumns(String catalog, String schemaPattern,
             String tableNamePattern, String columnNamePattern) {

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3685,7 +3685,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet {
      * @param columnIndex the column index (1, 2, ...)
      * @param type the class of the returned value
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public <T> T getObject(int columnIndex, Class<T> type) {
         return null;
@@ -3698,7 +3698,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet {
      * @param columnName the column name
      * @param type the class of the returned value
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public <T> T getObject(String columnName, Class<T> type) {
         return null;

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -929,7 +929,7 @@ public class JdbcStatement extends TraceObject implements Statement {
     /**
      * [Not supported]
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public void closeOnCompletion() {
         // not supported
@@ -939,7 +939,7 @@ public class JdbcStatement extends TraceObject implements Statement {
     /**
      * [Not supported]
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public boolean isCloseOnCompletion() {
         return true;

--- a/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
@@ -31,7 +31,7 @@ import javax.sql.PooledConnection;
 import org.h2.util.New;
 import org.h2.message.DbException;
 
-/*## Java 1.7 ##
+//## Java 1.7 ##
 import java.util.logging.Logger;
 //*/
 
@@ -333,7 +333,7 @@ public class JdbcConnectionPool implements DataSource, ConnectionEventListener {
     /**
      * [Not supported]
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public Logger getParentLogger() {
         return null;

--- a/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
@@ -25,7 +25,7 @@ import org.h2.jdbc.JdbcConnection;
 import org.h2.message.TraceObject;
 import org.h2.util.StringUtils;
 
-/*## Java 1.7 ##
+//## Java 1.7 ##
 import java.util.logging.Logger;
 //*/
 
@@ -425,7 +425,7 @@ public class JdbcDataSource extends TraceObject implements XADataSource,
     /**
      * [Not supported]
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public Logger getParentLogger() {
         return null;

--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -821,7 +821,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData {
      * @param columnIndex the column index (1, 2, ...)
      * @param type the class of the returned value
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public <T> T getObject(int columnIndex, Class<T> type) {
         return null;
@@ -834,7 +834,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData {
      * @param columnName the column name
      * @param type the class of the returned value
      */
-/*## Java 1.7 ##
+//## Java 1.7 ##
     @Override
     public <T> T getObject(String columnName, Class<T> type) {
         return null;

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -176,8 +176,9 @@ public class ValueGeometry extends Value {
      */
     public boolean intersectsBoundingBox(ValueGeometry r) {
         // the Geometry object caches the envelope
-        return getGeometryNoCopy().getEnvelopeInternal().intersects(
-                r.getGeometryNoCopy().getEnvelopeInternal());
+        return getGeometryNoCopy().intersects(r.getGeometryNoCopy());
+        /*return getGeometryNoCopy().getEnvelopeInternal().intersects(
+                r.getGeometryNoCopy().getEnvelopeInternal());*/
     }
 
     /**
@@ -189,7 +190,7 @@ public class ValueGeometry extends Value {
      */
     public boolean coversBoundingBox(ValueGeometry r) {
         // the Geometry object caches the envelope
-        return r.getGeometryNoCopy().getEnvelopeInternal().covers(getGeometryNoCopy().getEnvelopeInternal());
+        return r.getGeometryNoCopy().covers(getGeometryNoCopy());
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -91,6 +91,11 @@ public class ValueGeometry extends Value {
         return finder.isFoundZ() ? 3 : 2;
     }
 
+    public static ValueGeometry expandGeometry(Value g, Double r) {
+        Geometry gCopy = ((ValueGeometry)g).getGeometry();
+        return get(gCopy.buffer(r));
+    }
+
     /**
      * Get or create a geometry value for the given geometry.
      *
@@ -177,10 +182,19 @@ public class ValueGeometry extends Value {
     public boolean coversBoundingBox(ValueGeometry r) {
         // the Geometry object caches the envelope
         return r.getGeometryNoCopy().getEnvelopeInternal().covers(getGeometryNoCopy().getEnvelopeInternal());
-                //getGeometryNoCopy().getEnvelopeInternal()
-                //.covers(r.getGeometryNoCopy().getEnvelopeInternal());
-                //.intersects(
-                //r.getGeometryNoCopy().getEnvelopeInternal());
+    }
+
+    /**
+     * Given this geometry and a distance, compute a value geometry that contains this geometry and everything within
+     * dist of the boundary of this geometry
+     *
+     * @param dist
+     * @return
+     */
+    public ValueGeometry getBoundingRegion(double dist) {
+        Geometry g = getGeometry();
+        g.getEnvelopeInternal().expandBy(dist);
+        return get(g);
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -96,6 +96,14 @@ public class ValueGeometry extends Value {
         return get(gCopy.buffer(r));
     }
 
+    public ValueGeometry expandGeometry(Double r) {
+        Geometry gCopy = this.getGeometry();
+        System.out.println("GEO EXPANDED BOUNDS: " + gCopy.toText() );
+        ValueGeometry g = get(gCopy.buffer(r));
+        System.out.println("GEO EXPANDED BOUNDS: " + g.getGeometryNoCopy().toText() );
+        return g;
+    }
+
     /**
      * Get or create a geometry value for the given geometry.
      *
@@ -193,7 +201,10 @@ public class ValueGeometry extends Value {
      */
     public ValueGeometry getBoundingRegion(double dist) {
         Geometry g = getGeometry();
+        System.out.println("GEO BOUNDS: " + g.toText() );
+        // Expanded by doesn't do what we think it does?
         g.getEnvelopeInternal().expandBy(dist);
+        System.out.println("GEO EXPANDED BOUNDS: " + g.toText() );
         return get(g);
     }
 

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -168,6 +168,22 @@ public class ValueGeometry extends Value {
     }
 
     /**
+     * Test if this geometry envelope completely covers the other geometry
+     * envelope.
+     *
+     * @param r the other geometry
+     * @return true if the two overlap
+     */
+    public boolean coversBoundingBox(ValueGeometry r) {
+        // the Geometry object caches the envelope
+        return r.getGeometryNoCopy().getEnvelopeInternal().covers(getGeometryNoCopy().getEnvelopeInternal());
+                //getGeometryNoCopy().getEnvelopeInternal()
+                //.covers(r.getGeometryNoCopy().getEnvelopeInternal());
+                //.intersects(
+                //r.getGeometryNoCopy().getEnvelopeInternal());
+    }
+
+    /**
      * Get the union.
      *
      * @param r the other geometry


### PR DESCRIPTION
This PR will track the work necessary for supporting a couple additional operations on Geometry types in H2. Currently, H2 supports Geometry columns in WKT format, and supports an "envelope intersection" operation. We want to add support for 2 additional operations in query conditions:

"COVERS": This operator should return true if the first geometry completely contains the second (boundary inclusive).

"EXPAND": This operator should take a geometry and a distance (radius), and return a geometry that contains all points within distance of the input geometry.

COVERS will allow us to query for points in polygons, and that, in conjunction with EXPAND will allow for queries that select points within a distance of a polygon. 

So far, we've got rough drafts of Covers and Expands, however this is incomplete, especially with regards to the handling of index conditions for these new operators (which is after all why we are adding these functions to H2, to leverage H2s internal Spatial Indexes on queries for geometries near or within other geometries). 
